### PR TITLE
Feature: Set destination struct field `nil` on `zero` after copying

### DIFF
--- a/struct_tag.go
+++ b/struct_tag.go
@@ -7,10 +7,11 @@ import (
 
 // fieldDetail stores field copying detail parsed from a struct field
 type fieldDetail struct {
-	field    *reflect.StructField
-	key      string
-	ignored  bool
-	required bool
+	field     *reflect.StructField
+	key       string
+	ignored   bool
+	required  bool
+	nilOnZero bool
 
 	done         bool
 	index        []int
@@ -42,8 +43,17 @@ func parseTag(detail *fieldDetail) {
 	}
 
 	for _, tagOpt := range tags[1:] {
-		if tagOpt == "required" && !detail.ignored {
-			detail.required = true
+		switch tagOpt {
+		case "required":
+			if !detail.ignored {
+				detail.required = true
+			}
+		case "nilonzero":
+			k := detail.field.Type.Kind()
+			// Set nil on zero only applies to types which can set `nil`
+			if k == reflect.Pointer || k == reflect.Interface || k == reflect.Slice || k == reflect.Map {
+				detail.nilOnZero = true
+			}
 		}
 	}
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,50 @@
+package deepcopy
+
+import (
+	"reflect"
+)
+
+// structFieldGetWithInit gets deep nested field with init value for pointer ones
+func structFieldGetWithInit(field reflect.Value, index []int) reflect.Value {
+	for _, idx := range index {
+		if field.Kind() == reflect.Pointer {
+			if field.IsNil() {
+				field.Set(reflect.New(field.Type().Elem()))
+			}
+			field = field.Elem()
+		}
+		field = field.Field(idx)
+	}
+	return field
+}
+
+// structFieldSetZero sets zero to a deep nested field
+func structFieldSetZero(field reflect.Value, index []int) {
+	field, err := field.FieldByIndexErr(index)
+	if err == nil && field.IsValid() {
+		field.Set(reflect.Zero(field.Type())) // NOTE: Go1.18 has no SetZero
+	}
+}
+
+// nillableValueSetNilOnZero sets value as `nil` when its inner value is zero.
+// Only applies to `Pointer`, `Interface`, `Slice` and `Map` types.
+func nillableValueSetNilOnZero(val reflect.Value) {
+	innerVal := val
+	for {
+		switch innerVal.Kind() { //nolint:exhaustive
+		case reflect.Pointer, reflect.Interface:
+			innerVal = innerVal.Elem()
+			if !innerVal.IsValid() || innerVal.IsZero() {
+				val.Set(reflect.Zero(val.Type())) // NOTE: Go1.18 has no SetZero
+				return
+			}
+		case reflect.Slice, reflect.Map:
+			if innerVal.Len() == 0 {
+				val.Set(reflect.Zero(val.Type())) // NOTE: Go1.18 has no SetZero
+			}
+			return // always return as we can't go deeper with a slice or map
+		default:
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Why
- We need this function in practical when we don't want to send zero values to client, but null

## What
- Supports tag `nilonzero` on destination struct