### PR TITLE
Fix copier cache race

### DIFF
--- a/build_copier.go
+++ b/build_copier.go
@@ -216,13 +216,13 @@ OnNonCopyable:
 }
 
 func setCachedCopier(ctx *Context, cacheKey *cacheKey, cp copier) {
-	ctx.mu.RLock()
+	ctx.mu.Lock()
 	ctx.copierCacheMap[*cacheKey] = cp
-	ctx.mu.RUnlock()
+	ctx.mu.Unlock()
 }
 
 func deleteCachedCopier(ctx *Context, cacheKey *cacheKey) {
-	ctx.mu.RLock()
+	ctx.mu.Lock()
 	delete(ctx.copierCacheMap, *cacheKey)
-	ctx.mu.RUnlock()
+	ctx.mu.Unlock()
 }


### PR DESCRIPTION
hi @tiendc,

I think there is a data race in copier cache operation. 

`setCachedCopier` and `deleteCachedCopier` should use `Lock` instead of `RLock`, otherwise the `copierCacheMap` could be read and write concurrently, which could cause a panic: `fatal error: concurrent map read and map write`