### PR TITLE
Refactor: use direct assignment for same struct types and convertible types

### DIFF
--- a/base_copier.go
+++ b/base_copier.go
@@ -28,9 +28,7 @@ type value2PtrCopier struct {
 
 // Copy implementation of Copy function for value-to-pointer copier
 func (c *value2PtrCopier) Copy(dst, src reflect.Value) error {
-	if dst.IsNil() {
-		dst.Set(reflect.New(dst.Type().Elem()))
-	}
+	dst.Set(reflect.New(dst.Type().Elem()))
 	dst = dst.Elem()
 	return c.copier.Copy(dst, src)
 }
@@ -74,9 +72,8 @@ func (c *ptr2PtrCopier) Copy(dst, src reflect.Value) error {
 		dst.Set(reflect.Zero(dst.Type())) // NOTE: Go1.18 has no SetZero
 		return nil
 	}
-	if dst.IsNil() {
-		dst.Set(reflect.New(dst.Type().Elem()))
-	}
+
+	dst.Set(reflect.New(dst.Type().Elem()))
 	dst = dst.Elem()
 	return c.copier.Copy(dst, src)
 }

--- a/map_copier.go
+++ b/map_copier.go
@@ -17,9 +17,7 @@ func (c *mapCopier) Copy(dst, src reflect.Value) (err error) {
 		dst.Set(reflect.Zero(dst.Type())) // NOTE: Go1.18 has no SetZero
 		return nil
 	}
-	if dst.IsNil() {
-		dst.Set(reflect.MakeMapWithSize(dst.Type(), src.Len()))
-	}
+	dst.Set(reflect.MakeMapWithSize(dst.Type(), src.Len()))
 	iter := src.MapRange()
 	for iter.Next() {
 		k := iter.Key()

--- a/struct_copier_test.go
+++ b/struct_copier_test.go
@@ -207,6 +207,43 @@ func Test_Copy_struct(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, DD{I: 1, Ref: &DD{I: 2, Ref: &DD{I: 3}}}, d)
 	})
+
+	t.Run("#12: copy values of same struct", func(t *testing.T) {
+		type SS2 struct {
+			I int
+		}
+		type SS struct {
+			I   int
+			Ref *SS2
+		}
+
+		var s SS = SS{I: 1, Ref: &SS2{I: 2}}
+		var d SS
+		err := Copy(&d, s)
+		assert.Nil(t, err)
+		assert.Equal(t, s, d)
+		// Changes the src, they must become different
+		s.Ref.I++
+		assert.NotEqual(t, s, d)
+	})
+
+	t.Run("#13: copy from derived struct", func(t *testing.T) {
+		type SS2 struct {
+			I int
+		}
+		type SS struct {
+			I   int
+			Ref *SS2
+		}
+		type DD SS
+
+		var s SS = SS{I: 1, Ref: &SS2{I: 2}}
+		var d DD
+		err := Copy(&d, s)
+		assert.Nil(t, err)
+		assert.NotEqual(t, s, d)
+		assert.Equal(t, DD{I: 1, Ref: &SS2{I: 2}}, d)
+	})
 }
 
 func Test_Copy_struct_error(t *testing.T) {
@@ -404,6 +441,7 @@ func Test_Copy_struct_unexported_error(t *testing.T) {
 		type DD struct {
 			I int
 			u uint `copy:",required"`
+			S string
 		}
 
 		var s SS = SS{I: 1, u: 2}


### PR DESCRIPTION
## Why
- The current code always try to copy between structs manually. But it's better to use direct assignment by checking `AssignableTo` or `ConvertibleTo`.

## What
- If structs are assignable or convertible, perform direct assignments
- Ignores copying for any struct field of primitive types as they are already handled by the above step
- Handles fields of pointer/slice/map/... types to make sure `dst` and `src` won't share any data