### PR TITLE
Fix: requires copying when  struct fields are exported

### DIFF
--- a/struct_copier.go
+++ b/struct_copier.go
@@ -272,7 +272,7 @@ func (c *structCopier) createField2FieldCopier(df, sf *fieldDetail, cp copier) c
 		dstFieldSetNilOnZero: df.nilOnZero,
 		srcFieldIndex:        sf.index,
 		srcFieldUnexported:   !sf.field.IsExported(),
-		required:             sf.required || df.required,
+		required:             sf.required || df.required || df.field.IsExported(),
 	}
 }
 


### PR DESCRIPTION
## Why
- Should require the copying to be done if the destination struct fields are exported, so error can be reported to users in case of failure.