### PR TITLE
Refactor: rename util function structParseMethods

### DIFF
--- a/struct_copier.go
+++ b/struct_copier.go
@@ -39,7 +39,7 @@ func (c *structCopier) Copy(dst, src reflect.Value) error {
 
 //nolint:gocognit,gocyclo
 func (c *structCopier) init(dstType, srcType reflect.Type) (err error) {
-	dstCopyingMethods := structParseMethods(c.ctx, dstType)
+	dstCopyingMethods := typeParseMethods(c.ctx, dstType)
 	if postCopyMethod, ok := dstCopyingMethods[structPostCopyMethodName]; ok {
 		c.postCopyMethod = &postCopyMethod.Index
 	}

--- a/struct_to_map_copier.go
+++ b/struct_to_map_copier.go
@@ -57,7 +57,7 @@ func (c *structToMapCopier) init(dstType, srcType reflect.Type) (err error) {
 			ErrTypeNonCopyable, srcType, mapKeyType, mapValType)
 	}
 
-	dstCopyingMethods := structParseMethods(c.ctx, dstType)
+	dstCopyingMethods := typeParseMethods(c.ctx, dstType)
 	if postCopyMethod, ok := dstCopyingMethods[structPostCopyMethodName]; ok {
 		c.postCopyMethod = &postCopyMethod.Index
 	}

--- a/util.go
+++ b/util.go
@@ -15,9 +15,9 @@ const (
 	structPostCopyMethodName = "PostCopy"
 )
 
-// structParseMethods collects all copying methods from the given struct type
-func structParseMethods(ctx *Context, structType reflect.Type) map[string]*reflect.Method {
-	ptrType := reflect.PointerTo(structType)
+// typeParseMethods collects all copying methods from the given type
+func typeParseMethods(ctx *Context, typ reflect.Type) map[string]*reflect.Method {
+	ptrType := reflect.PointerTo(typ)
 	numMethods := ptrType.NumMethod()
 	result := make(map[string]*reflect.Method, numMethods)
 	for i := 0; i < numMethods; i++ {


### PR DESCRIPTION
## Why
- This function is for any type, not only structs.