### PR TITLE
FIx: correct the condition for requiring copy for struct field

### DIFF
--- a/map_to_struct_copier.go
+++ b/map_to_struct_copier.go
@@ -218,20 +218,17 @@ func (c *value2StructFieldCopier) Copy(dst, src reflect.Value) (err error) {
 		dst = structFieldGetWithInit(dst, c.dstFieldIndex)
 	}
 	if c.dstFieldUnexported {
-		if !dst.CanAddr() {
-			if c.required {
-				return fmt.Errorf("%w: accessing unexported destination field requires it to be addressable",
-					ErrValueUnaddressable)
-			}
-			return nil
-		}
+		// NOTE: dst is always addressable as Copy() requires `dst` to be pointer
 		dst = reflect.NewAt(dst.Type(), unsafe.Pointer(dst.UnsafeAddr())).Elem() //nolint:gosec
 	}
 
 	// Use custom copier if set
 	if c.copier != nil {
 		if err = c.copier.Copy(dst, src); err != nil {
-			return err
+			if c.required {
+				return err
+			}
+			return nil
 		}
 	} else {
 		// Otherwise, just perform simple direct copying

--- a/struct_to_map_copier.go
+++ b/struct_to_map_copier.go
@@ -144,11 +144,10 @@ func (c *structToMapCopier) buildCopier(mapKeyType, mapValueType, srcStructType 
 
 func (c *structToMapCopier) createField2MethodCopier(dM *reflect.Method, sfDetail *fieldDetail) copier {
 	return &structField2MethodCopier{
-		dstMethod:           dM.Index,
-		dstMethodUnexported: !dM.IsExported(),
-		srcFieldIndex:       sfDetail.index,
-		srcFieldUnexported:  !sfDetail.field.IsExported(),
-		required:            sfDetail.required,
+		dstMethod:          dM.Index,
+		srcFieldIndex:      sfDetail.index,
+		srcFieldUnexported: !sfDetail.field.IsExported(),
+		required:           sfDetail.required || sfDetail.field.IsExported(),
 	}
 }
 
@@ -159,7 +158,7 @@ func (c *structToMapCopier) createField2MapEntryCopier(sf *fieldDetail, key refl
 		valueCopier:        valueCopier,
 		srcFieldIndex:      sf.index,
 		srcFieldUnexported: !sf.field.IsExported(),
-		required:           sf.required,
+		required:           sf.required || sf.field.IsExported(),
 	}
 }
 
@@ -200,7 +199,10 @@ func (c *structField2MapEntryCopier) Copy(dst, src reflect.Value) (err error) {
 
 	if c.valueCopier != nil {
 		if src, err = c.valueCopier.Copy(src); err != nil {
-			return err
+			if c.required {
+				return err
+			}
+			return nil
 		}
 	}
 	dst.SetMapIndex(c.key, src)

--- a/struct_to_map_copier_test.go
+++ b/struct_to_map_copier_test.go
@@ -270,6 +270,17 @@ func Test_Copy_structToMap_error(t *testing.T) {
 		err := Copy(&d, &s)
 		assert.ErrorIs(t, err, ErrTypeNonCopyable)
 	})
+
+	t.Run("#5: non-copyable, but field requires copying", func(t *testing.T) {
+		type SS struct {
+			P unsafe.Pointer `copy:",required"`
+		}
+
+		s := SS{P: nil}
+		var d map[string]unsafe.Pointer
+		err := Copy(&d, &s, IgnoreNonCopyableTypes(true))
+		assert.ErrorIs(t, err, ErrFieldRequireCopying)
+	})
 }
 
 func Test_Copy_structToMap_unexported(t *testing.T) {


### PR DESCRIPTION
## Why
- Some conditions for when require copying struct fields are not consistent

## What
- Now requires copying struct fields is they are configured or the fields are exported
- Refactored: remove redundant checks of addressable on `dst` as they are always addressable
- Added more UT